### PR TITLE
Support ListLikes that don't implement @@iterator

### DIFF
--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -103,6 +103,18 @@ QUnit.test("eachIndex", function(){
 		QUnit.equal(index, 0);
 		QUnit.equal(value, "a");
 	});
+
+	function ArrayLike() {}
+	ArrayLike.prototype = new Array();
+	ArrayLike.prototype[canSymbol.iterator] = null;
+
+	var noniterator = new ArrayLike();
+	noniterator.push("a");
+	shapeReflections.eachIndex(noniterator, function(value, index){
+		QUnit.equal(index, 0);
+		QUnit.equal(value,"a");
+	});
+
 });
 
 QUnit.test("eachKey", function(){

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -15,14 +15,13 @@ var shapeReflections = {
 
 	// each index in something list-like. Uses iterator if it has it.
 	eachIndex: function(list, callback, context){
-		var iter;
+		var iter, iterator = list[canSymbol.iterator];
 		if(Array.isArray(list)) {
 			// do nothing
 		} else if(typeReflections.isIteratorLike(list)) {
-			// we are looping through an interator
+			// we are looping through an iterator
 			iter = list;
-		} else {
-			var iterator = list[canSymbol.iterator];
+		} else if(iterator) {
 			iter = iterator.call(list);
 		}
 		// fast-path arrays


### PR DESCRIPTION
Though part of my efforts on [can-define] involve implementing `Symbol.iterator` for DefineList, having iterators is not the expected behavior for many list-likes, so this is a small fix to ensure that `list[Symbol.iterator]` isn't expected to exist.