### PR TITLE
Remove cssify configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-reflect",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "donejs"
   ],


### PR DESCRIPTION
It’s not used and it breaks Browserify usage.