### PR TITLE
Check for existence of is[Map/List/Value]Like symbols during type tests

### DIFF
--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -37,7 +37,11 @@ QUnit.test("isListLike", function(){
 	ok(typeReflections.isListLike({
 		length: 0
 	}), "object with 0 length");
-
+	var symboled = {};
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isListLike"), false);
+	ok(!typeReflections.isListLike(symboled), "!@@can.isListLike");
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isListLike"), true);
+	ok(typeReflections.isListLike(symboled), "@@can.isListLike");
 
 	if(typeof document !== "undefined") {
 		var ul = document.createElement("ul");
@@ -52,6 +56,11 @@ QUnit.test("isListLike", function(){
 QUnit.test("isMapLike", function(){
 	ok(typeReflections.isMapLike({}), "Object");
 	ok(typeReflections.isMapLike([]), "Array");
+	var symboled = {};
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isMapLike"), false);
+	ok(!typeReflections.isMapLike(symboled), "!@@can.isMapLike");
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isMapLike"), true);
+	ok(typeReflections.isMapLike(symboled), "@@can.isMapLike");
 
 	ok(!typeReflections.isMapLike("String"), "String");
 });
@@ -82,6 +91,12 @@ QUnit.test("isValueLike", function(){
 	var obj = {};
 	getSetReflections.setKeyValue(obj,canSymbol.for("can.getValue"), true);
 	ok(typeReflections.isValueLike(obj), "symboled");
+	var symboled = {};
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isValueLike"), false);
+	ok(!typeReflections.isValueLike(symboled), "!@@can.isValueLike");
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isValueLike"), true);
+	ok(typeReflections.isValueLike(symboled), "@@can.isValueLike");
+
 });
 
 QUnit.test("isSymbolLike", function(){

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -45,8 +45,13 @@ function isPrimitive(obj){
 }
 
 function isValueLike(obj) {
+	var symbolValue;
 	if(isPrimitive(obj)) {
 		return true;
+	}
+	symbolValue = obj[canSymbol.for("can.isValueLike")];
+	if( typeof symbolValue !== "undefined") {
+		return symbolValue;
 	}
 	var value = obj[canSymbol.for("can.getValue")];
 	if(value !== undefined) {
@@ -55,8 +60,13 @@ function isValueLike(obj) {
 }
 
 function isMapLike(obj) {
+	var symbolValue;
 	if(isPrimitive(obj)) {
 		return false;
+	}
+	symbolValue = obj[canSymbol.for("can.isMapLike")];
+	if( typeof symbolValue !== "undefined") {
+		return symbolValue;
 	}
 	var value = obj[canSymbol.for("can.getKeyValue")];
 	if(value !== undefined) {
@@ -77,12 +87,17 @@ function isObservableLike( obj ) {
 }
 
 function isListLike( list ) {
-	var type = typeof list;
+	var symbolValue,
+		type = typeof list;
 	if(type === "string") {
 		return true;
 	}
 	if( isPrimitive(list) ) {
 		return false;
+	}
+	symbolValue = list[canSymbol.for("can.isListLike")];
+	if( typeof symbolValue !== "undefined") {
+		return symbolValue;
 	}
 	var value = list[canSymbol.iterator];
 	if(value !== undefined) {


### PR DESCRIPTION
Object types can define `@@can.isMapLike`, `@@can.isValueLike`, and `@@can.isListLike` as symbols, and these should take precedence over inference methods, like whether `@@can.getValue` exists.