### PR TITLE
Made isBuiltIn and return non-POJO built-ins on serialize

### DIFF
--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -304,9 +304,17 @@ if(typeof Map !== "undefined") {
 }
 
 QUnit.test("isBuiltIn is only called after decorators are checked in shouldSerialize", function() {
-	var set = new Set([{}, {}, {}]);
-	set[canSymbol.for("can.setKeyValue")];
-	QUnit.ok(!shapeReflections.shouldSerialize(set));
+	var arr = [];
+	QUnit.ok(shapeReflections.shouldSerialize(arr));
+	arr[canSymbol.for('can.setKeyValue')] = function() {};
+	QUnit.ok(!shapeReflections.shouldSerialize(arr));
+
+	if (Set) {
+		var set = new Set([{}, {}, {}]);
+		QUnit.ok(shapeReflections.shouldSerialize(set));
+		set[canSymbol.for("can.setKeyValue")] = function() {};
+		QUnit.ok(!shapeReflections.shouldSerialize(set));
+	}
 });
 
 QUnit.test(".serialize handles recursion with .unwrap", function(){

--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -303,6 +303,12 @@ if(typeof Map !== "undefined") {
 	});
 }
 
+QUnit.test("isBuiltIn is only called after decorators are checked in shouldSerialize", function() {
+	var set = new Set([{}, {}, {}]);
+	set[canSymbol.for("can.setKeyValue")];
+	QUnit.ok(!shapeReflections.shouldSerialize(set));
+});
+
 QUnit.test(".serialize handles recursion with .unwrap", function(){
 
 

--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -305,15 +305,15 @@ if(typeof Map !== "undefined") {
 
 QUnit.test("isBuiltIn is only called after decorators are checked in shouldSerialize", function() {
 	var arr = [];
-	QUnit.ok(shapeReflections.shouldSerialize(arr));
+	QUnit.ok(shapeReflections.isSerializable(arr));
 	arr[canSymbol.for('can.setKeyValue')] = function() {};
-	QUnit.ok(!shapeReflections.shouldSerialize(arr));
+	QUnit.ok(!shapeReflections.isSerializable(arr));
 
 	if (Set) {
 		var set = new Set([{}, {}, {}]);
-		QUnit.ok(shapeReflections.shouldSerialize(set));
+		QUnit.ok(shapeReflections.isSerializable(set));
 		set[canSymbol.for("can.setKeyValue")] = function() {};
-		QUnit.ok(!shapeReflections.shouldSerialize(set));
+		QUnit.ok(!shapeReflections.isSerializable(set));
 	}
 });
 

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -46,10 +46,9 @@ try{
 function makeSerializer(methodName, symbolsToCheck){
 
 	return function serializer(value, MapType ){
-		if( typeReflections.isPrimitive(value) ) {
+		if(typeReflections.isBuiltIn(value) && !typeReflections.isPlainObject(value)) {
 			return value;
 		}
-
 
 		var firstSerialize;
 		if(MapType && !serializeMap) {

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -19,14 +19,20 @@ var shiftedSetKeyValue = shiftFirstArgumentToThis(getSetReflections.setKeyValue)
 
 var serializeMap = null;
 
-function shouldSerialize(obj){
-	return typeof obj !== "function";
-}
-
 var hasUpdateSymbol = helpers.makeGetFirstSymbolValue(["can.updateDeep","can.assignDeep","can.setKeyValue"]);
 var shouldUpdateOrAssign = function(obj){
 	return typeReflections.isPlainObject(obj) || Array.isArray(obj) || !!hasUpdateSymbol(obj);
 };
+
+function shouldSerialize(obj){
+	if (typeReflections.isPrimitive(obj)) {
+		return true;
+	}
+	if(hasUpdateSymbol) {
+		return false;
+	}
+	return typeReflections.isBuiltIn(obj);
+}
 
 // IE11 doesn't support primitives
 var Object_Keys;
@@ -46,7 +52,7 @@ try{
 function makeSerializer(methodName, symbolsToCheck){
 
 	return function serializer(value, MapType ){
-		if(typeReflections.isBuiltIn(value) && !typeReflections.isPlainObject(value)) {
+		if (shouldSerialize(value)) {
 			return value;
 		}
 
@@ -91,7 +97,7 @@ function makeSerializer(methodName, symbolsToCheck){
 				}
 			}
 
-			if(!shouldSerialize(value)) {
+			if (typeof obj ==='function') {
 				if(serializeMap) {
 					serializeMap[methodName].set(value, value);
 				}
@@ -685,7 +691,8 @@ var shapeReflections = {
 			getSetReflections.setKeyValue(target, canSymbol.for(key), value);
 		});
 		return target;
-	}
+	},
+	shouldSerialize: shouldSerialize
 };
 shapeReflections.keys = shapeReflections.getOwnEnumerableKeys;
 module.exports = shapeReflections;

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -63,8 +63,7 @@ function makeSerializer(methodName, symbolsToCheck){
 			serialized = this[methodName]( getSetReflections.getValue(value) );
 
 		} else {
-			// if this is a POJO, do nothing
-			// if it's a Date, RegExp, Map, etc ... do nothing
+			// POJO, Date, RegEx and other Built-ins are handled above
 			// only want to do something if it's intended to be serialized
 
 			var isListLike = typeReflections.isIteratorLike(value) || typeReflections.isMoreListLikeThanMapLike(value);

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -63,7 +63,7 @@ function makeSerializer(methodName, symbolsToCheck){
 			serialized = this[methodName]( getSetReflections.getValue(value) );
 
 		} else {
-			// Date, RegEx and other Built-ins are handled above as built-ins
+			// Date, RegEx and other Built-ins are handled above
 			// only want to do something if it's intended to be serialized
 			// or do nothing for a POJO
 

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -24,7 +24,7 @@ var shouldUpdateOrAssign = function(obj){
 	return typeReflections.isPlainObject(obj) || Array.isArray(obj) || !!hasUpdateSymbol(obj);
 };
 
-function shouldSerialize(obj){
+function isSerializable(obj){
 	if (typeReflections.isPrimitive(obj)) {
 		return true;
 	}
@@ -52,7 +52,7 @@ try{
 function makeSerializer(methodName, symbolsToCheck){
 
 	return function serializer(value, MapType ){
-		if (shouldSerialize(value)) {
+		if (isSerializable(value)) {
 			return value;
 		}
 
@@ -692,7 +692,7 @@ var shapeReflections = {
 		});
 		return target;
 	},
-	shouldSerialize: shouldSerialize
+	isSerializable: isSerializable
 };
 shapeReflections.keys = shapeReflections.getOwnEnumerableKeys;
 module.exports = shapeReflections;

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -28,10 +28,10 @@ function shouldSerialize(obj){
 	if (typeReflections.isPrimitive(obj)) {
 		return true;
 	}
-	if(hasUpdateSymbol) {
+	if(hasUpdateSymbol(obj)) {
 		return false;
 	}
-	return typeReflections.isBuiltIn(obj);
+	return typeReflections.isBuiltIn(obj) && !typeReflections.isPlainObject(obj);
 }
 
 // IE11 doesn't support primitives

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -63,8 +63,9 @@ function makeSerializer(methodName, symbolsToCheck){
 			serialized = this[methodName]( getSetReflections.getValue(value) );
 
 		} else {
-			// POJO, Date, RegEx and other Built-ins are handled above
+			// Date, RegEx and other Built-ins are handled above as built-ins
 			// only want to do something if it's intended to be serialized
+			// or do nothing for a POJO
 
 			var isListLike = typeReflections.isIteratorLike(value) || typeReflections.isMoreListLikeThanMapLike(value);
 			serialized = isListLike ? [] : {};

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -122,9 +122,7 @@ QUnit.test("isBuiltIn", function() {
 	ok(!typeReflections.isBuiltIn(customObj), "Custom Object");
 	if (typeof Map !== 'undefined') {
 		var map = new Map();
-		getSetReflections.setKeyValue(Map.prototype, canSymbol.for('can.getKeyValue'), true);
 		ok(typeReflections.isBuiltIn(map), "Map");
-		delete Map.prototype[canSymbol.for('can.getKeyValue')];
 	}
 });
 

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -114,10 +114,18 @@ QUnit.test("isBuiltIn", function() {
 	ok(typeReflections.isBuiltIn(function() {}), "Function");
 	ok(typeReflections.isBuiltIn(new Date()), "Date");
 	ok(typeReflections.isBuiltIn(/[foo].[bar]/), "RegEx");
-	ok(typeReflections.isBuiltIn(document.createElement('div')), "Elements");
+	if (document) {
+		ok(typeReflections.isBuiltIn(document.createElement('div')), "Elements");
+	}
 	var Foo = function() {}
 	var customObj = new Foo();
 	ok(!typeReflections.isBuiltIn(customObj), "Custom Object");
+	if (typeof Map !== 'undefined') {
+		var map = new Map();
+		getSetReflections.setKeyValue(Map.prototype, canSymbol.for('can.getKeyValue'), true);
+		ok(typeReflections.isBuiltIn(map), "Map");
+		delete Map.prototype[canSymbol.for('can.getKeyValue')];
+	}
 });
 
 QUnit.test("isValueLike", function(){

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -107,6 +107,19 @@ QUnit.test("isPrimitive", function(){
 	ok(typeReflections.isPrimitive(1), "1");
 });
 
+QUnit.test("isBuiltIn", function() {
+	ok(typeReflections.isBuiltIn(1), "Primitive");
+	ok(typeReflections.isBuiltIn({}), "Object");
+	ok(typeReflections.isBuiltIn([]), "Array");
+	ok(typeReflections.isBuiltIn(function() {}), "Function");
+	ok(typeReflections.isBuiltIn(new Date()), "Date");
+	ok(typeReflections.isBuiltIn(/[foo].[bar]/), "RegEx");
+	ok(typeReflections.isBuiltIn(document.createElement('div')), "Elements");
+	var Foo = function() {}
+	var customObj = new Foo();
+	ok(!typeReflections.isBuiltIn(customObj), "Custom Object");
+});
+
 QUnit.test("isValueLike", function(){
 	ok(!typeReflections.isValueLike({}), "Object");
 	ok(!typeReflections.isValueLike(function(){}), "Function");

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -156,6 +156,10 @@ function isPrimitive(obj){
  * @return {Boolean}
  */
 function isBuiltIn(obj) {
+
+	// If primitive, array, or POJO return true. Also check if
+	// it is not a POJO but is some type like [object Date] or
+	// [object Regex] and return true.
 	if (isPrimitive(obj) ||
 		Array.isArray(obj) ||
 		isPlainObject(obj) ||

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -137,7 +137,7 @@ function isPrimitive(obj){
  * @description Test if a value is a JavaScript built-in type.
  * @signature `isBuiltIn(obj)`
  *
- * Return `true` if `obj` is some type of native built-in JavaScript type; `false` otherwise.
+ * Return `true` if `obj` is some type of JavaScript native built-in; `false` otherwise.
  *
  * ```
  * canReflect.isBuiltIn(null); // -> true
@@ -156,15 +156,15 @@ function isPrimitive(obj){
  * @return {Boolean}
  */
 function isBuiltIn(obj) {
-	if (!isPlainObject(obj)) {
-		if (isPrimitive(obj) || Array.isArray(obj) || 
-		(Object.prototype.toString.call(obj) !== '[object Object]' && Object.prototype.toString.call(obj).indexOf('[object ') !== -1)) {
-			return true;
-		}
-		return false;
+	if (isPrimitive(obj) ||
+		Array.isArray(obj) ||
+		isPlainObject(obj) ||
+		(Object.prototype.toString.call(obj) !== '[object Object]' && 
+			Object.prototype.toString.call(obj).indexOf('[object ') !== -1)) {
+		return true;
 	}
 	else {
-		return true;
+		return false;
 	}
 }
 

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -125,8 +125,46 @@ function isPrimitive(obj){
 	var type = typeof obj;
 	if(obj == null || (type !== "function" && type !== "object") ) {
 		return true;
-	} else {
+	}
+	else {
 		return false;
+	}
+}
+
+/**
+ * @function can-reflect.isBuiltIn isBuiltIn
+ * @parent can-reflect/type
+ * @description Test if a value is a JavaScript built-in type.
+ * @signature `isBuiltIn(obj)`
+ *
+ * Return `true` if `obj` is some type of native built-in JavaScript type; `false` otherwise.
+ *
+ * ```
+ * canReflect.isBuiltIn(null); // -> true
+ * canReflect.isBuiltIn({}); // -> true 
+ * canReflect.isBuiltIn(1); // -> true
+ * canReflect.isBuiltIn([]); // -> true
+ * canReflect.isBuiltIn(function() {}); // -> true
+ * canReflect.isBuiltIn("foo"); // -> true
+ * canReflect.isBuiltIn(new Date()); // -> true
+ * canReflect.isBuiltIn(/[foo].[bar]/); // -> true
+ * canReflect.isBuiltIn(new DefineMap); // -> false
+ *
+ * ```
+ *
+ * @param  {*}  obj maybe a built-in value
+ * @return {Boolean}
+ */
+function isBuiltIn(obj) {
+	if (!isPlainObject(obj)) {
+		if (isPrimitive(obj) || Array.isArray(obj) || 
+		(Object.prototype.toString.call(obj) !== '[object Object]' && Object.prototype.toString.call(obj).indexOf('[object ') !== -1)) {
+			return true;
+		}
+		return false;
+	}
+	else {
+		return true;
 	}
 }
 
@@ -384,6 +422,7 @@ module.exports = {
 	isMapLike: isMapLike,
 	isObservableLike: isObservableLike,
 	isPrimitive: isPrimitive,
+	isBuiltIn: isBuiltIn,
 	isValueLike: isValueLike,
 	isSymbolLike: isSymbolLike,
 	/**


### PR DESCRIPTION
Made a `isBuiltIn` function and use it to just return built-in values (besides POJOs) when `serializer` is ran.

This will prevent things like dates or regex from returning an empty object instead of their serialized value.

for https://github.com/canjs/can-define/issues/237