### PR TITLE
Added helpers to see is map/set are implemented and properly supported

### DIFF
--- a/can-reflect-test_helpers.js
+++ b/can-reflect-test_helpers.js
@@ -1,0 +1,26 @@
+var canSymbol = require('can-symbol');
+
+var mapSupported = (function() {
+	if (typeof Map !== "undefined" && typeof Map.prototype.keys === "function") {
+		var myMap = new Map();
+		return myMap.toString() === '[object Map]';
+	}
+
+	return false;
+}());
+
+var setSupported = (function() {
+	if (typeof Set !== "undefined") {
+		var mySet = new Set();
+		return mySet.toString() === '[object Set]' && canSymbol.iterator in mySet;
+	}
+
+	return false;
+}());
+
+var helpers = {
+	mapSupported: mapSupported,
+	setSupported: setSupported	
+};
+
+module.exports = helpers;

--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -2,10 +2,7 @@ var QUnit = require('steal-qunit');
 var canSymbol = require('can-symbol');
 var shapeReflections = require("./shape");
 var getSetReflections = require("../get-set/get-set");
-
-var mapSupported = (function() {
-	return typeof Map !== "undefined" && typeof Map.prototype.keys === "function";
-}());
+var testHelpers = require('../../can-reflect-test_helpers');
 
 QUnit.module('can-reflect: shape reflections: own+enumerable');
 
@@ -16,7 +13,7 @@ function testModifiedMap(callback, symbolToMethod){
 		getKeyValue: "get"
 	};
 
-	if(mapSupported) {
+	if(testHelpers.mapSupported) {
 		shapeReflections.eachKey(symbolToMethod, function(method, symbol){
 			getSetReflections.setKeyValue(Map.prototype,canSymbol.for("can."+symbol),function(){
 				return this[method].apply(this, arguments);
@@ -309,7 +306,7 @@ QUnit.test("isBuiltIn is only called after decorators are checked in shouldSeria
 	arr[canSymbol.for('can.setKeyValue')] = function() {};
 	QUnit.ok(!shapeReflections.isSerializable(arr));
 
-	if (Set) {
+	if (testHelpers.setSupported) {
 		var set = new Set([{}, {}, {}]);
 		QUnit.ok(shapeReflections.isSerializable(set));
 		set[canSymbol.for("can.setKeyValue")] = function() {};

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -2,16 +2,7 @@ var QUnit = require('steal-qunit');
 var canSymbol = require('can-symbol');
 var typeReflections = require("./type");
 var getSetReflections = require("../get-set/get-set");
-
-var setSupported = (function(){
-	if (typeof Set === "undefined") {
-		return false;
-	}
-
-	var theSet = new Set();
-
-	return canSymbol.iterator in theSet;
-}());
+var testHelpers = require('../../can-reflect-test_helpers');
 
 QUnit.module('can-reflect: type reflections');
 
@@ -71,7 +62,7 @@ QUnit.test("isListLike", function(){
 		ul.innerHTML = "<li/><li/>";
 		ok(typeReflections.isListLike(ul.childNodes), "nodeList");
 	}
-	if(setSupported) {
+	if(testHelpers.setSupported) {
 		ok(typeReflections.isListLike(new Set()), "Set");
 	}
 });
@@ -120,7 +111,7 @@ QUnit.test("isBuiltIn", function() {
 	var Foo = function() {}
 	var customObj = new Foo();
 	ok(!typeReflections.isBuiltIn(customObj), "Custom Object");
-	if (typeof Map !== 'undefined') {
+	if (testHelpers.mapSupported) {
 		var map = new Map();
 		ok(typeReflections.isBuiltIn(map), "Map");
 	}

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -153,7 +153,7 @@ function isPrimitive(obj){
  * ```
  * 
  * Not supported in browsers that have implementations of Map/Set where
- * toString is not properly implemented to return [object Map]/[object Set].
+ * `toString` is not properly implemented to return `[object Map]`/`[object Set]`.
  *
  * @param  {*}  obj maybe a built-in value
  * @return {Boolean}

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -151,6 +151,9 @@ function isPrimitive(obj){
  * canReflect.isBuiltIn(new DefineMap); // -> false
  *
  * ```
+ * 
+ * Not supported in browsers that have implementations of Map/Set where
+ * toString is not properly implemented to return [object Map]/[object Set].
  *
  * @param  {*}  obj maybe a built-in value
  * @return {Boolean}


### PR DESCRIPTION
IE 9/10 do not support Map/Set and even using `if(Map) {}` will cause an error.

Switched to using `typeof Map !== 'undefined`

In addition in IE 11 Map/Set do not properly have `toString` defined and will return `[object Object]` rather than `[object Set]` or `[object Map]` so functions were made in a test helpers module to check for these cases.

For #38 