### PR TITLE
Fixing support for Map and Set in IE11

### DIFF
--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -127,7 +127,7 @@ function makeSerializer(methodName, symbolsToCheck){
 
 // returns a Map type of the keys mapped to true
 var makeMap;
-if(typeof Map !== "undefined") {
+if (typeof Map !== "undefined" && typeof Map.prototype.keys !== "undefined") {
 	makeMap = function(keys) {
 		var map = new Map();
 		shapeReflections.eachIndex(keys, function(key){

--- a/types/map-test.js
+++ b/types/map-test.js
@@ -2,7 +2,7 @@ var QUnit = require("steal-qunit");
 var shape = require("../reflections/shape/shape");
 require("./map");
 
-if(typeof Map !== "undefined") {
+if (typeof Map !== "undefined" && typeof Map.prototype.keys !== "undefined") {
     QUnit.module("can-reflect/types/map Map");
 
     QUnit.test("assign", function(){
@@ -51,31 +51,33 @@ if(typeof Map !== "undefined") {
 }
 
 
-if(typeof WeakMap !== "undefined") {
+if (typeof WeakMap !== "undefined") {
     QUnit.module("can-reflect/types/map WeakMap");
 
-    QUnit.test("assign", function(){
-        var canjs = new Map();
-        var name = {name: "toUpperCase"};
-        canjs.set(name, "CANJS");
+	if (typeof Map !== "undefined" && typeof Map.prototype.keys !== "undefined") {
+		QUnit.test("assign", function(){
+			var canjs = new Map();
+			var name = {name: "toUpperCase"};
+			canjs.set(name, "CANJS");
 
-        var map = new WeakMap();
+			var map = new WeakMap();
 
-        shape.assign( map, canjs );
-        QUnit.equal( map.get(name), "CANJS" , "map to weakmap");
+			shape.assign( map, canjs );
+			QUnit.equal( map.get(name), "CANJS" , "map to weakmap");
 
 
-        map = new WeakMap();
+			map = new WeakMap();
 
-        var map1 = new Map();
-        var o1 = {name: "foo"};
-        var o2 = {name: "bar"};
-        map1.set(o1, o2);
+			var map1 = new Map();
+			var o1 = {name: "foo"};
+			var o2 = {name: "bar"};
+			map1.set(o1, o2);
 
-        shape.assign( map, map1 );
-        QUnit.equal( map.get(o1), o2 , "map to map");
+			shape.assign( map, map1 );
+			QUnit.equal( map.get(o1), o2 , "map to map");
 
-    });
+		});
+	}
 
     QUnit.test("has", function(){
         var map = new WeakMap();

--- a/types/map.js
+++ b/types/map.js
@@ -1,6 +1,6 @@
 var shape = require("../reflections/shape/shape");
 
-if (typeof Map !== "undefined") {
+if (typeof Map !== "undefined" && typeof Map.prototype.keys !== "undefined") {
   shape.assignSymbols(Map.prototype, {
     "can.getOwnEnumerableKeys": Map.prototype.keys,
     "can.setKeyValue": Map.prototype.set,

--- a/types/set-test.js
+++ b/types/set-test.js
@@ -3,6 +3,14 @@ var shape = require("../reflections/shape/shape");
 var type = require("../reflections/type/type");
 require("./set");
 
+function assertSetMatchesArray(set, array, msg) {
+	QUnit.equal(set.size, array.length, msg + " - size matches");
+
+	for (var i=0; i<array.length; i++) {
+		QUnit.ok(set.has(array[i]), msg + " - set contains " + array[i]);
+	}
+}
+
 if(typeof Set !== "undefined") {
     QUnit.module("can-reflect/types/set Set");
 
@@ -14,7 +22,10 @@ if(typeof Set !== "undefined") {
 
     QUnit.test("shape.each", function(){
         var arr = ["a","b"];
-        var set = new Set(arr);
+        var set = new Set();
+        arr.forEach(function(val) {
+          set.add(val);
+        });
 
         var count = 0;
         shape.each(set, function(value){
@@ -27,19 +38,19 @@ if(typeof Set !== "undefined") {
 
         shape.update(set, ["a","a","c"]);
 
-        QUnit.deepEqual( Array.from(set), [
-            "a","c"
-        ], ".update");
+        assertSetMatchesArray(set, [ "a", "c" ], ".update");
     });
 
     QUnit.test("shape.assign", function(){
-        var set = new Set(["a","b"]);
+        var arr = ["a","b"];
+        var set = new Set();
+        arr.forEach(function(val) {
+          set.add(val);
+        });
 
         shape.assign(set, ["a","a","c"]);
 
-        QUnit.deepEqual( Array.from(set), [
-            "a","b","c"
-        ], ".assign");
+        assertSetMatchesArray(set, [ "a", "b", "c" ], ".assign");
     });
 }
 

--- a/types/set.js
+++ b/types/set.js
@@ -1,4 +1,5 @@
 var shape = require("../reflections/shape/shape");
+var CanSymbol = require("can-symbol");
 
 if (typeof Set !== "undefined") {
   shape.assignSymbols(Set.prototype, {
@@ -25,6 +26,27 @@ if (typeof Set !== "undefined") {
       return this.size;
     }
   });
+
+  // IE11 doesn't support Set.prototype[@@iterator]
+  if (typeof Set.prototype[CanSymbol.iterator] !== "function") {
+	  Set.prototype[CanSymbol.iterator] = function() {
+		  var arr = [];
+		  var currentIndex = 0;
+
+		  this.forEach(function(val) {
+			  arr.push(val);
+		  });
+
+		  return {
+			  next: function() {
+				  return {
+					  value: arr[currentIndex],
+					  done: (currentIndex++ === arr.length)
+				  };
+			  }
+		  }
+	  };
+  }
 }
 if (typeof WeakSet !== "undefined") {
   shape.assignSymbols(WeakSet.prototype, {


### PR DESCRIPTION
IE11 supports Map and Set but not Map.prototype.keys, Array.from, new Set(iterator), or Set.prototype[@@iterator].

closes https://github.com/canjs/can-reflect/issues/48.