### PR TITLE
Fixed observableLike to default to returning false

### DIFF
--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -85,7 +85,8 @@ QUnit.test("isMoreListLikeThanMapLike", function(){
 });
 
 QUnit.test("isObservableLike", function(){
-	ok(!typeReflections.isObservableLike({}), "Object");
+	ok(typeReflections.isObservableLike({}) === false, "Object");
+	ok(typeReflections.isObservableLike([]) === false, "Array");
 
 	var obj = {};
 	getSetReflections.setKeyValue(obj,canSymbol.for("can.onValue"), function(){});

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -294,6 +294,7 @@ function isObservableLike( obj ) {
 	if(result !== undefined) {
 		return !!result;
 	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
Prior to this fix:
```js
canReflect.isObservableLike([]) //undefined
canReflect.isObservableLike({}) //undefined
canReflect.isObservableLike(null) //false
```
Expected/fixed behavior:
```
canReflect.isObservableLike([]) //false
canReflect.isObservableLike({}) //false
canReflect.isObservableLike(null) //false
```