### PR TITLE
onInstanceBoundChange, defineInstanceKey, onInstanceBatches, onPatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "donejs"
   ],
   "dependencies": {
-    "can-assign": "^1.0.1",
     "can-namespace": "^1.0.0",
     "can-symbol": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "donejs"
   ],
   "dependencies": {
+    "can-assign": "^1.0.1",
     "can-namespace": "^1.0.0",
     "can-symbol": "^1.3.0"
   },

--- a/reflections/observe/observe.js
+++ b/reflections/observe/observe.js
@@ -242,7 +242,7 @@ module.exports = {
 	 * @parent can-reflect/observe
 	 * @description  Register an event handler on an observable ValueLike object, based on a change in its value
 	 *
-	 * @signature `onValue(handler)`
+	 * @signature `onValue(handler, [queueName])`
 	 *
 	 * Register an event handler on the Value-like object `obj` to trigger when its value changes.
 	 * `obj` *must* implement [can-symbol/symbols/onValue @@@@can.onValue] to be compatible with
@@ -267,7 +267,7 @@ module.exports = {
 	 * @parent can-reflect/observe
 	 * @description  Unregister an value change handler from an observable ValueLike object
 	 *
-	 * @signature `offValue(handler)`
+	 * @signature `offValue(handler, [queueName])`
 	 *
 	 * Unregister an event handler from the Value-like object `obj` that had previously been registered with
 	 * [can-reflect/observe.onValue onValue]. The function passed as `handler` will no longer be called
@@ -359,9 +359,90 @@ module.exports = {
 	 * @return {Boolean} `true` if there are other dependencies that may update the object's value; `false` otherwise
 	 *
 	 */
-	// TODO: use getValueDeps once we know what that needs to look like
 	valueHasDependencies: makeErrorIfMissing("can.valueHasDependencies","can-reflect: can not determine if value has dependencies"),
 
+	// HAS BINDINGS VS DOES NOT HAVE BINDINGS
+	/**
+	 * @function {Object, function(*), String} can-reflect/observe.onBoundChange onBoundChange
+	 * @parent can-reflect/observe
+	 * @description  Register an handler on an observable that listens to its bound state
+	 *
+	 * @signature `onBoundChange(obj, handler, [queueName])`
+	 *
+	 * Register an event handler on the object `obj` that fires when the object becomes bound (the first handler is added) 
+	 * or unbound (the last remaining handler is removed). The function passed as `handler` will be called
+	 * with `true` as the first argument when `obj` gains its first binding, and called with `false` when `obj` loses its 
+	 * last binding.
+	 *
+	 * ```
+	 * var obj = new DefineMap({});
+	 * var handler = function(newVal) {
+	 * 	console.log("Bound state is now", newVal);
+	 * };
+	 * var keyHandler = function() {};
+	 *
+	 * canReflect.onBoundChange(obj, handler);
+	 * canReflect.onKeyValue(obj, "foo", keyHandler);  // logs "Bound state is now true"
+	 * canReflect.offKeyValue(obj, "foo", keyHandler);  // logs "Bound state is now false"
+	 * ```
+	 *
+	 * @param {*} obj
+	 * @param {function(*)} handler
+	 * @param {String} [queueName] the name of a queue in [can-queues]; dispatches to `handler` will happen on this queue
+	 */
+	onBoundChange: makeErrorIfMissing("can.onBoundChange", "can-reflect: can not observe bound state change"),
+	/**
+	 * @function {Object, function(*), String} can-reflect/observe.offBoundChange offBoundChange
+	 * @parent can-reflect/observe
+	 * @description  Unregister a bound state handler from an observable object
+	 *
+	 * @signature `offBoundChange(obj, handler, [queueName])`
+	 *
+	 * Unregister an event handler from the object `obj` that had previously been registered with
+	 * [can-reflect/observe.onValue offBoundChange]. The function passed as `handler` will no longer be called
+	 * when `obj` gains its first or loses its last binding.
+	 *
+	 * ```
+	 * var obj = new DefineMap({});
+	 * var handler = function(newVal, oldVal) {
+	 * 	console.log("compute is now", newVal, ", was", oldVal);
+	 * };
+	 *
+	 * canReflect.onBoundChange(obj, handler);
+	 * canReflect.offBoundChange(obj, handler);
+	 *
+	 * canReflect.onKeyValue(obj, "foo", function() {});  // nothing is logged
+	 * ```
+	 *
+	 * @param {*} obj
+	 * @param {function(*)} handler
+	 * @param {String} [queueName] the name of the queue in [can-queues] the handler was registered under
+	 */
+	offBoundChange: makeErrorIfMissing("can.offBoundChange", "can-reflect: can not unobserve bound state change"),
+	/**
+	 * @function {Object} can-reflect/observe.isBound isBound
+	 * @parent can-reflect/observe
+	 * @description  Determine whether any listeners are bound to the observable object
+	 *
+	 * @signature `isBound(obj)`
+	 *
+	 * `isBound` queries an observable object to find out whether any listeners have been set on it using
+	 * [can-reflect/observe.onKeyValue onKeyValue] or [can-reflect/observe.onValue onValue]
+	 *
+	 * ```
+	 * var obj = new DefineMap({});
+	 * var handler = function() {};
+	 * canReflect.isBound(obj); // -> false
+	 * canReflect.onKeyValue(obj, "foo", handler);
+	 * canReflect.isBound(obj); // -> true
+	 * canReflect.offKeyValue(obj, "foo", handler);
+	 * canReflect.isBound(obj); // -> false
+	 * ```
+	 *
+	 * @param {*} obj
+	 * @return {Boolean} `true` if obj has at least one key-value or value listener, `false` otherwise
+	 */
+	isBound: makeErrorIfMissing("can.isBound", "can-reflect: cannot determine if object is bound"),
 
 	// EVENT
 	/**

--- a/reflections/observe/observe.js
+++ b/reflections/observe/observe.js
@@ -374,7 +374,7 @@ module.exports = {
 	 * Register an event handler on the object `obj` that fires when anything changes on an object: a key value is added,
 	 * an existing key has is value changed, or a key is deleted from the object.
 	 *
-	 * If object is an array-like and the changed property includes numeric indexes, patch sets will include array-specific 
+	 * If object is an array-like and the changed property includes numeric indexes, patch sets will include array-specific
 	 * patches in addition to object-style patches
 	 *
 	 * For more on the patch formats, see [can-util/js/diff-object/diff-object] and [can-util/js/diff-array/diff-array].
@@ -391,9 +391,9 @@ module.exports = {
 	 *
 	 * var arr = new DefineList([]);
 	 * canReflect.onPatches(arr, handler);
-	 * arr.push("foo");  // logs [{type: "add", property:"0", value: "foo"}, 
+	 * arr.push("foo");  // logs [{type: "add", property:"0", value: "foo"},
 	 *                            {index: 0, deleteCount: 0, insert: ["foo"]}]
-   * arr.pop();  // logs [{type: "remove", property:"0"}, 
+   * arr.pop();  // logs [{type: "remove", property:"0"},
 	 *                            {index: 0, deleteCount: 1, insert: []}]
 	 * ```
 	 *
@@ -433,62 +433,68 @@ module.exports = {
 
 	// HAS BINDINGS VS DOES NOT HAVE BINDINGS
 	/**
-	 * @function {Object, function(*), String} can-reflect/observe.onBoundChange onBoundChange
+	 * @function {Object, function(*), String} can-reflect/observe.onInstanceBoundChange onInstanceBoundChange
 	 * @parent can-reflect/observe
-	 * @description  Register an handler on an observable that listens to its bound state
+	 * @description Listen to when observables of a type are bound and unbound.
 	 *
-	 * @signature `onBoundChange(obj, handler, [queueName])`
+	 * @signature `onInstanceBoundChange(Type, handler, [queueName])`
 	 *
-	 * Register an event handler on the object `obj` that fires when the object becomes bound (the first handler is added) 
+	 * Register an event handler on the object `Type` that fires when instances of the type become bound (the first handler is added)
 	 * or unbound (the last remaining handler is removed). The function passed as `handler` will be called
-	 * with `true` as the first argument when `obj` gains its first binding, and called with `false` when `obj` loses its 
+	 * with the `instance` as the first argument and `true` as the second argument when `instance` gains its first binding,
+	 * and called with `false` when `instance` loses its
 	 * last binding.
 	 *
 	 * ```
-	 * var obj = new DefineMap({});
-	 * var handler = function(newVal) {
-	 * 	console.log("Bound state is now", newVal);
+	 * Person = DefineMap.extend({ ... });
+	 *
+	 * var person = Person({});
+	 * var handler = function(instance, newVal) {
+	 * 	console.log(instance, "bound state is now", newVal);
 	 * };
 	 * var keyHandler = function() {};
 	 *
-	 * canReflect.onBoundChange(obj, handler);
-	 * canReflect.onKeyValue(obj, "foo", keyHandler);  // logs "Bound state is now true"
-	 * canReflect.offKeyValue(obj, "foo", keyHandler);  // logs "Bound state is now false"
+	 * canReflect.onInstanceBoundChange(Person, handler);
+	 * canReflect.onKeyValue(obj, "name", keyHandler);  // logs person Bound state is now true
+	 * canReflect.offKeyValue(obj, "name", keyHandler);  // logs person Bound state is now false
 	 * ```
 	 *
-	 * @param {*} obj
-	 * @param {function(*)} handler
+	 * @param {function} Type A constructor function
+	 * @param {function(*,Boolean)} handler(instance,isBound) A function called with the `instance` whose bound status changed and the state of the bound status.
 	 * @param {String} [queueName] the name of a queue in [can-queues]; dispatches to `handler` will happen on this queue
 	 */
-	onBoundChange: makeErrorIfMissing("can.onBoundChange", "can-reflect: can not observe bound state change"),
+	onInstanceBoundChange: makeErrorIfMissing("can.onInstanceBoundChange", "can-reflect: can not observe bound state change in instances."),
 	/**
-	 * @function {Object, function(*), String} can-reflect/observe.offBoundChange offBoundChange
+	 * @function {Object, function(*), String} can-reflect/observe.offInstanceBoundChange offInstanceBoundChange
 	 * @parent can-reflect/observe
-	 * @description  Unregister a bound state handler from an observable object
+	 * @description Stop listening to when observables of a type are bound and unbound.
 	 *
-	 * @signature `offBoundChange(obj, handler, [queueName])`
+	 * @signature `offInstanceBoundChange(Type, handler, [queueName])`
 	 *
-	 * Unregister an event handler from the object `obj` that had previously been registered with
-	 * [can-reflect/observe.onBoundChange onBoundChange]. The function passed as `handler` will no longer be called
-	 * when `obj` gains its first or loses its last binding.
+	 * Unregister an event handler from the type `Type` that had previously been registered with
+	 * [can-reflect/observe.onInstanceBoundChange onInstanceBoundChange]. The function passed as `handler` will no longer be called
+	 * when instances of `Type` gains its first or loses its last binding.
 	 *
 	 * ```
-	 * var obj = new DefineMap({});
-	 * var handler = function(newVal, oldVal) {
-	 * 	console.log("compute is now", newVal, ", was", oldVal);
+	 * Person = DefineMap.extend({ ... });
+	 *
+	 * var person = Person({});
+	 * var handler = function(instance, newVal) {
+	 * 	console.log(instance, "bound state is now", newVal);
 	 * };
+	 * var keyHandler = function() {};
 	 *
-	 * canReflect.onBoundChange(obj, handler);
-	 * canReflect.offBoundChange(obj, handler);
-	 *
-	 * canReflect.onKeyValue(obj, "foo", function() {});  // nothing is logged
+	 * canReflect.onInstanceBoundChange(Person, handler);
+	 * canReflect.offInstanceBoundChange(Person, handler);
+	 * canReflect.onKeyValue(obj, "name", keyHandler);  // nothing is logged
+	 * canReflect.offKeyValue(obj, "name", keyHandler); // nothing is logged
 	 * ```
 	 *
-	 * @param {*} obj
-	 * @param {function(*)} handler
+	 * @param {function} Type A constructor function
+	 * @param {function(*,Boolean)} handler(instance,isBound) The `handler` passed to `canReflect.onInstanceBoundChange`.
 	 * @param {String} [queueName] the name of the queue in [can-queues] the handler was registered under
 	 */
-	offBoundChange: makeErrorIfMissing("can.offBoundChange", "can-reflect: can not unobserve bound state change"),
+	offInstanceBoundChange: makeErrorIfMissing("can.offInstanceBoundChange", "can-reflect: can not unobserve bound state change"),
 	/**
 	 * @function {Object} can-reflect/observe.isBound isBound
 	 * @parent can-reflect/observe
@@ -677,7 +683,7 @@ module.exports = {
 	 * symbol.
 	 *
 	 * @body
-	 * 
+	 *
 	 */
 	getPriority: function(obj) {
 		if(obj) {

--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -466,6 +466,33 @@ if(typeof Symbol !== "undefined") {
 }
 
 
+QUnit.test("defineInstanceKey with symbol on prototype", function() {
+	var testKey = "foo";
+	var testDef = { value: "bar" };
+
+	function Foo() {}
+	Foo.prototype[canSymbol.for("can.defineInstanceKey")] = function(key, definition) {
+		QUnit.equal(key, testKey);
+		QUnit.deepEqual(definition, testDef);
+	};
+	shapeReflections.defineInstanceKey(Foo, testKey, testDef);
+});
+
+QUnit.test("defineInstanceKey with no symbol on prototype", function() {
+	var testKey = "foo";
+	var testDef = { value: "bar" };
+	var def;
+
+	function Foo() {}
+	shapeReflections.defineInstanceKey(Foo, testKey, testDef);
+
+	QUnit.ok(def = Object.getOwnPropertyDescriptor(Foo.prototype, testKey), "Has descriptor");
+	QUnit.equal(def.value, testDef.value, "Value is correctly set");
+	QUnit.equal(def.configurable, true, "value is configurable");
+	QUnit.equal(def.writable, true, "value is writable");
+
+});
+
 /*QUnit.module('can-reflect: shape reflections: proto chain');
 
 QUnit.test("in", function(){

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -2,7 +2,6 @@ var canSymbol = require("can-symbol");
 var getSetReflections = require("../get-set/get-set");
 var typeReflections = require("../type/type");
 var helpers = require("../helpers");
-var assign = require("can-assign");
 
 var shapeReflections;
 
@@ -959,10 +958,10 @@ shapeReflections = {
 	 *
 	 * @signature `defineInstanceKey(cls, key, properties)`
 	 *
-	 * Define the property `key` on the prototype of the constructor `cls` using the symbolic 
+	 * Define the property `key` on the prototype of the constructor `cls` using the symbolic
 	 * property [can-symbol/symbols/defineInstanceKey @@can.defineInstanceKey] if it exists; otherwise
-	 * use `Object.defineProperty()` to define the property.  The property definition 
-	 * 
+	 * use `Object.defineProperty()` to define the property.  The property definition
+	 *
 	 * @param  {Function} cls  a Constructor function
 	 * @param  {String} key     the String or Symbol key to set.
 	 * @param  {Object} properties a JavaScript property descriptor
@@ -976,10 +975,10 @@ shapeReflections = {
 			Object.defineProperty(
 				proto,
 				key,
-				assign({
+				shapeReflections.assign({
 					configurable: true,
 					enumerable: !typeReflections.isSymbolLike(key),
-					writable: true 
+					writable: true
 				}, properties)
 			);
 		}

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -2,6 +2,7 @@ var canSymbol = require("can-symbol");
 var getSetReflections = require("../get-set/get-set");
 var typeReflections = require("../type/type");
 var helpers = require("../helpers");
+var assign = require("can-assign");
 
 var shapeReflections;
 
@@ -132,7 +133,7 @@ if(typeof Map !== "undefined") {
 		var map = new Map();
 		shapeReflections.eachIndex(keys, function(key){
 			map.set(key, true);
-		})
+		});
 		return map;
 	};
 } else {
@@ -150,7 +151,7 @@ if(typeof Map !== "undefined") {
 				map[key] = value;
 			},
 			keys: function(){
-				return keys
+				return keys;
 			}
 		};
 	};
@@ -166,7 +167,7 @@ var fastHasOwnKey = function(obj){
 	} else {
 		var map = makeMap( shapeReflections.getOwnEnumerableKeys(obj) );
 		return function(key) {
-			return map.get(key)
+			return map.get(key);
 		};
 	}
 };
@@ -803,7 +804,7 @@ shapeReflections = {
 			if(sourceKeyMap.get(key)) {
 				targetSetKeyValue.call(target, key, sourceGetKeyValue.call(source, key) );
 			}
-		})
+		});
 		return target;
 	},
 	updateDeepList: function(target, source) {
@@ -929,7 +930,7 @@ shapeReflections = {
 			return size.call(obj);
 		}
 		else if(helpers.hasLength(obj)){
-			return obj.length
+			return obj.length;
 		}
 		else if(typeReflections.isListLike(obj)){
 
@@ -949,6 +950,38 @@ shapeReflections = {
 		}
 		else {
 			return undefined;
+		}
+	},
+	/**
+	 * @function {Function, String|Symbol, Object} can-reflect/shape.defineInstanceKey defineInstanceKey
+	 * @parent can-reflect/shape
+	 * @description Create a key for all instances of a constructor.
+	 *
+	 * @signature `defineInstanceKey(cls, key, properties)`
+	 *
+	 * Define the property `key` on the prototype of the constructor `cls` using the symbolic 
+	 * property [can-symbol/symbols/defineInstanceKey @@can.defineInstanceKey] if it exists; otherwise
+	 * use `Object.defineProperty()` to define the property.  The property definition 
+	 * 
+	 * @param  {Function} cls  a Constructor function
+	 * @param  {String} key     the String or Symbol key to set.
+	 * @param  {Object} properties a JavaScript property descriptor
+	 */
+	defineInstanceKey: function(cls, key, properties) {
+		var proto = cls.prototype;
+		var sym = proto[canSymbol.for("can.defineInstanceKey")];
+		if(sym) {
+			sym.call(proto, key, properties);
+		} else {
+			Object.defineProperty(
+				proto,
+				key,
+				assign({
+					configurable: true,
+					enumerable: !typeReflections.isSymbolLike(key),
+					writable: true 
+				}, properties)
+			);
 		}
 	}
 };

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -967,10 +967,14 @@ shapeReflections = {
 	 * @param  {Object} properties a JavaScript property descriptor
 	 */
 	defineInstanceKey: function(cls, key, properties) {
+		var defineInstanceKey = cls[canSymbol.for("can.defineInstanceKey")];
+		if(defineInstanceKey) {
+			return defineInstanceKey.call(cls, key, properties);
+		}
 		var proto = cls.prototype;
-		var sym = proto[canSymbol.for("can.defineInstanceKey")];
-		if(sym) {
-			sym.call(proto, key, properties);
+		defineInstanceKey = proto[canSymbol.for("can.defineInstanceKey")];
+		if(defineInstanceKey) {
+			defineInstanceKey.call(proto, key, properties);
 		} else {
 			Object.defineProperty(
 				proto,


### PR DESCRIPTION
This adds:
- defineInstanceKey - define a key behavior on instances of a type
- onInstanceBoundChange - listen to when instances of this type are bound or unbound
- onInstanceBatches - listen to the patches events of all instances of this type
- onPatches - listen to patch events on this type