### PR TITLE
Hide getWhatIChange and getChangesDependencyRecord

### DIFF
--- a/reflections/observe/observe.js
+++ b/reflections/observe/observe.js
@@ -198,6 +198,7 @@ module.exports = {
 
 	/**
 	 * @function {Object, String} can-reflect/observe.getWhatIChange getWhatIChange
+	 * @hide
 	 * @parent can-reflect/observe
 	 * @description Return the observable objects that derive their value from the
 	 * obj, passed in.
@@ -218,6 +219,7 @@ module.exports = {
 
 	/**
 	 * @function {Function} can-reflect/observe.getChangesDependencyRecord getChangesDependencyRecord
+	 * @hide
 	 * @parent can-reflect/observe
 	 * @description Return the observable objects that are mutated by the handler
 	 * passed in as argument.

--- a/reflections/observe/observe.js
+++ b/reflections/observe/observe.js
@@ -213,7 +213,7 @@ module.exports = {
 	 * @return {Object} the observable values that derive their value from `obj`
 	 */
 	getWhatIChange: makeErrorIfMissing(
-		"can.getKeyDependencies",
+		"can.getWhatIChange",
 		"can-reflect: can not determine dependencies"
 	),
 


### PR DESCRIPTION
From the generated docs.

Closes #82 and #84