### PR TITLE
Handle cycles in serialize()

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "donejs"
   ],
   "dependencies": {
+    "can-cid": "^1.1.2",
     "can-namespace": "^1.0.0",
     "can-symbol": "^1.3.0"
   },

--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -294,6 +294,7 @@ if(typeof Map !== "undefined") {
 
 		a.b = b;
 		b.a = a;
+		
 		var plain = shapeReflections.unwrap(a, Map);
 		QUnit.equal(plain.b.a, plain, "cycle intact");
 		QUnit.ok( a !== plain , "returns copy");
@@ -364,6 +365,14 @@ QUnit.test(".serialize handles recursion with .unwrap", function(){
 		list: [0,2,4]
 	});
 
+});
+
+QUnit.test(".serialize with recursive data structures", function(){
+	var obj = {};
+	obj.prop = obj;
+
+	var s = shapeReflections.serialize(obj);
+	QUnit.equal(s.prop, s, "Object points to itself");
 });
 
 QUnit.test("updateDeep basics", function(){

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -2,6 +2,7 @@ var canSymbol = require("can-symbol");
 var getSetReflections = require("../get-set/get-set");
 var typeReflections = require("../type/type");
 var helpers = require("../helpers");
+var CIDMap = require("can-cid/map/map");
 
 var shapeReflections;
 
@@ -54,22 +55,22 @@ try{
 
 function makeSerializer(methodName, symbolsToCheck){
 
-	return function serializer(value, MapType ){
+	return function serializer(value, MapType){
 		if (isSerializable(value)) {
 			return value;
 		}
 
 		var firstSerialize;
-		if(MapType && !serializeMap) {
+		if(!serializeMap) {
 			serializeMap = {
-				unwrap: new MapType(),
-				serialize: new MapType()
+				unwrap: MapType ? new MapType() : new CIDMap(),
+				serialize: MapType ? new MapType() : new CIDMap()
 			};
 			firstSerialize = true;
 		}
 		var serialized;
 		if(typeReflections.isValueLike(value)) {
-			serialized = this[methodName]( getSetReflections.getValue(value) );
+			serialized = this[methodName](getSetReflections.getValue(value));
 
 		} else {
 			// Date, RegEx and other Built-ins are handled above


### PR DESCRIPTION
This handles cycles in serialize() by using the same technique that
unwrap() uses to handle cycles. But since in this case we don't have a
MapType in which to work, we are just going to use Maps instead.

Closes #96