### PR TITLE
Remove dependency on can-cid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "donejs"
   ],
   "dependencies": {
-    "can-cid": "^1.1.2",
     "can-namespace": "^1.0.0",
     "can-symbol": "^1.3.0"
   },

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -7,6 +7,10 @@ var ArrayMap;
 if(typeof Map === "function") {
 	ArrayMap = Map;
 } else {
+	function isEven(num) {
+		return !(num % 2);
+	}
+
 	// A simple map that stores items in an array.
 	// like [key, value]
 	// You can find the value by searching for the key and then +1.
@@ -15,17 +19,29 @@ if(typeof Map === "function") {
 	};
 
 	ArrayMap.prototype = {
+		/**
+		 * Get an index of a key. Because we store boths keys and values in
+		 * a flat array, we ensure we are getting a key by checking that it is an
+		 * even number index (all keys are even number indexed).
+		 **/
+		_getIndex: function(key) {
+			var idx;
+			do {
+				idx = this.contents.indexOf(key, idx);
+			} while(idx !== -1 && !isEven(idx));
+			return idx;
+		},
 		has: function(key){
-			return this.contents.indexOf(key) !== -1;
+			return this._getIndex(key) !== -1;
 		},
 		get: function(key){
-			var idx = this.contents.indexOf(key);
+			var idx = this._getIndex(key);
 			if(idx !== -1) {
 				return this.contents[idx + 1];
 			}
 		},
 		set: function(key, value){
-			var idx = this.contents.indexOf(key);
+			var idx = this._getIndex(key);
 			if(idx !== -1) {
 				// Key already exists, replace the value.
 				this.contents[idx + 1] = value;

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -2,7 +2,40 @@ var canSymbol = require("can-symbol");
 var getSetReflections = require("../get-set/get-set");
 var typeReflections = require("../type/type");
 var helpers = require("../helpers");
-var CIDMap = require("can-cid/map/map");
+
+var ArrayMap;
+if(typeof Map === "function") {
+	ArrayMap = Map;
+} else {
+	// A simple map that stores items in an array.
+	// like [key, value]
+	// You can find the value by searching for the key and then +1.
+	ArrayMap = function(){
+		this.contents = [];
+	};
+
+	ArrayMap.prototype = {
+		has: function(key){
+			return this.contents.indexOf(key) !== -1;
+		},
+		get: function(key){
+			var idx = this.contents.indexOf(key);
+			if(idx !== -1) {
+				return this.contents[idx + 1];
+			}
+		},
+		set: function(key, value){
+			var idx = this.contents.indexOf(key);
+			if(idx !== -1) {
+				// Key already exists, replace the value.
+				this.contents[idx + 1] = value;
+			} else {
+				this.contents.push(key);
+				this.contents.push(value);
+			}
+		}
+	};
+}
 
 var shapeReflections;
 
@@ -63,8 +96,8 @@ function makeSerializer(methodName, symbolsToCheck){
 		var firstSerialize;
 		if(!serializeMap) {
 			serializeMap = {
-				unwrap: MapType ? new MapType() : new CIDMap(),
-				serialize: MapType ? new MapType() : new CIDMap()
+				unwrap: MapType ? new MapType() : new ArrayMap(),
+				serialize: MapType ? new MapType() : new ArrayMap()
 			};
 			firstSerialize = true;
 		}


### PR DESCRIPTION
This updates the cycles implementation to not depend on can-cid for its
Map polyfill. Instead inline a simple version.

Closes #98 