### PR TITLE
Reset global state when throwing b/c of circular refs

### DIFF
--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -436,7 +436,39 @@ QUnit.test("throw should not when serializing circular reference properly", func
 	}
 });
 
+QUnit.test("Correctly serializes after throwing for circular reference", function(){
+	function SimpleType(){}
+	var a = new SimpleType();
+	var b = new SimpleType();
+	a.b = b;
+	b.a = a;
+	getSetReflections.setKeyValue(a, canSymbol.for("can.serialize"), function(){
+		return {
+			b: shapeReflections.serialize(this.b)
+		};
+	});
+	getSetReflections.setKeyValue(b, canSymbol.for("can.serialize"), function(){
+		return {
+			a: shapeReflections.serialize(this.a)
+		};
+	});
 
+	try{
+		shapeReflections.serialize(a, window.Map);
+		QUnit.ok(false);
+	}catch(e){
+		QUnit.ok(true);
+
+		a = [1,2];
+		shapeReflections.serialize(a, window.Map);
+
+		b = a;
+		b.shift();
+		var s = shapeReflections.serialize(b, window.Map);
+		QUnit.equal(s.length, 1, "there is one item");
+		QUnit.equal(s[0], 2, "correct item");
+	}
+});
 
 QUnit.test("updateDeep basics", function(){
 


### PR DESCRIPTION
serialize() throws when it encounters a circular reference. However
because a global variable was being used, that global variable had
preserved state that would be reused in all future calls to serialize.

This caused a problem, particular with lists, which might be serialized
multiple times, being mutated in between serialization. In which case
they would always return the same (incorrect) value.

I fixed this by refactoring and making the global state a little more
explicit / easier to read, and providing a method `.end()` that does the
necessary clean up.

This will fix the failing canjs/canjs tests.