### PR TITLE
Make getSchema return undefined when passed undefined

### DIFF
--- a/reflections/shape/schema/schema-test.js
+++ b/reflections/shape/schema/schema-test.js
@@ -80,6 +80,12 @@ QUnit.test("getSchema returns undefined when there is not schema", function(){
 
 });
 
+QUnit.test("getSchema returns undefined when passed undefined", function(){
+
+    QUnit.equal(schemaReflections.getSchema(undefined), undefined, "is undefined");
+
+});
+
 QUnit.test("canReflect.convert", function(){
     var res =  schemaReflections.convert("1", Number);
     QUnit.equal(typeof res, "number", "is right type");

--- a/reflections/shape/schema/schema.js
+++ b/reflections/shape/schema/schema.js
@@ -103,6 +103,9 @@ var schemaReflections =  {
      *
 	 */
     getSchema: function(type){
+        if (type === undefined) {
+            return undefined;
+        }
         var getSchema = type[getSchemaSymbol];
         if(getSchema === undefined ) {
             type = type.constructor;


### PR DESCRIPTION
`canReflect.getSchema( undefined )` now returns `undefined`

Fixes https://github.com/canjs/can-diff/issues/2