### PR TITLE
Test latest Safari in Sauce Labs

### DIFF
--- a/test-saucelabs.js
+++ b/test-saucelabs.js
@@ -17,8 +17,8 @@ var platforms = [{
 	version: '11.0'
 }, {
 	browserName: 'safari',
-	platform: 'OS X 10.11',
-	version: '10.0'
+	platform: 'OS X 10.12',
+	version: 'latest'
 }, {
 	browserName: 'MicrosoftEdge',
 	platform: 'Windows 10'


### PR DESCRIPTION
This fixes an issue with tests passing in Safari 10 but Sauce Labs throwing an error:

```
Error checking test results: Error: [text([{"ELEMENT":"0"}])] Error response status: 10, , StaleElementReference - An element command failed because the referenced element is no longer attached to the DOM. Selenium error: Element is no longer attached to the DOM (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 8 milliseconds
For documentation on this error, please visit: http://seleniumhq.org/exceptions/stale_element_reference.html
Build info: version: '2.48.0', revision: 'b7b081a', time: '2015-10-07 15:48:56'
System info: host: 'itako21022.prod.miso', ip: '10.100.35.164', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.11.6', java.version: '1.8.0_102'
Driver info: org.openqa.selenium.safari.SafariDriver
Capabilities [{browserName=safari, takesScreenshot=true, javascriptEnabled=true, version=10.0.1, cssSelectorsEnabled=true, platform=MAC, secureSsl=true}]
Session ID: null
```