### PR TITLE
changing host for test-saucelabs script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - sleep 2
 script: npm run ci
 addons:
+  hosts: canjs.test
   sauce_connect: true
   firefox: '51.0'
 deploy:

--- a/test-saucelabs.js
+++ b/test-saucelabs.js
@@ -37,7 +37,7 @@ var platforms = [{
 	deviceName: 'iPhone 7 Simulator'
 }];
 
-var url = 'http://localhost:3000/test.html?hidepassed';
+var url = 'http://canjs.test:3000/test.html?hidepassed';
 
 SauceLabs({
 	urls: [{ name: "can-reflect", url : url }],


### PR DESCRIPTION
There is an issue with Safari not correctly using proxy servers when
using `localhost`
(https://support.saucelabs.com/hc/en-us/articles/115009908527
), which breaks Sauce labs tests that need SauceConnect. This change
maps localhost to http://canjs.test and updates the saucelabs script to
use this.

closes https://github.com/canjs/can-reflect/issues/128.