### PR TITLE
Fix canReflect.isFunctionLike(obj) for null/undefined

### DIFF
--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -38,6 +38,9 @@ QUnit.test("isFunctionLike", function(){
 
 	getSetReflections.setKeyValue(obj, canSymbol.for("can.isFunctionLike"), false);
 	ok(!typeReflections.isFunctionLike(obj), 'object with can.new, can.apply, and can.isFunctionLike set to false is not function like');
+
+	equal(typeReflections.isFunctionLike(null), false, 'null is not a function');
+	equal(typeReflections.isFunctionLike(undefined), false, 'undefined is not a function');
 });
 
 QUnit.test("isIteratorLike", function(){

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -86,7 +86,7 @@ function isConstructorLike(func){
 var getNewOrApply = helpers.makeGetFirstSymbolValue(["can.new","can.apply"]);
 function isFunctionLike(obj){
 	var result,
-		symbolValue = obj[canSymbol.for("can.isFunctionLike")];
+		symbolValue = !!obj && obj[canSymbol.for("can.isFunctionLike")];
 
 	if (symbolValue !== undefined) {
 		return symbolValue;


### PR DESCRIPTION
Fixes #135