### PR TITLE
assign deep should work recursively

### DIFF
--- a/reflections/shape/shape-test.js
+++ b/reflections/shape/shape-test.js
@@ -688,6 +688,21 @@ QUnit.test("each loops without needing `this`", function(){
 	QUnit.ok(true, "no error");
 });
 
+QUnit.test("assignDeepList", function(){
+	var justin = {name: "Justin", age: 35},
+		payal = {name: "Payal", age: 35};
+
+	var people = [justin, payal];
+	shapeReflections.assignDeep(people, [
+		{age: 36}
+	]);
+
+	QUnit.deepEqual(people,  [
+		{name: "Justin", age: 36},
+		{name: "Payal", age: 35}
+	], "assigned right");
+});
+
 
 /*QUnit.test("getAllEnumerableKeys", function(){
 

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -319,7 +319,12 @@ function updateDeepList(target, source, isAssign) {
 		if( typeReflections.isPrimitive(curVal) || typeReflections.isPrimitive(newVal) || shouldUpdateOrAssign(curVal) === false ) {
 			addPatch(patches, {index: index, deleteCount: 1, insert: [newVal]});
 		} else {
-			this.updateDeep(curVal, newVal);
+			if(isAssign === true) {
+				this.assignDeep(curVal, newVal);
+			} else {
+				this.updateDeep(curVal, newVal);
+			}
+
 		}
 	}, this);
 	// add items at the end


### PR DESCRIPTION
for #143 

essentially `assignDeep()` on a list was doing an assign on the list, but was doing updates on all items within the list.


This PR makes it so it does assigns recursively down.

It's possible people were expecting properties to be removed.  This will break those apps.
