### PR TITLE
Fixes #139. Adds other directories to jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "jshint": "jshint ./*.js --config",
+    "jshint": "jshint ./*.js reflections/**/*.js types/*.js --config",
     "build": "node build.js",
     "http-server": "http-server -p 3000 --silent",
     "ci": "npm run build && npm run test && node test-saucelabs.js",

--- a/reflections/get-set/get-set-test.js
+++ b/reflections/get-set/get-set-test.js
@@ -1,6 +1,5 @@
 var QUnit = require('steal-qunit');
 var canSymbol = require('can-symbol');
-var shapeReflections = require("../shape/shape");
 var getSetReflections = require("./get-set");
 
 QUnit.module('can-reflect: get-set reflections: key');

--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -20,7 +20,7 @@ if(typeof Map === "function") {
 } else {
 	// IE-remove-start
 	var isEven = function isEven(num) {
-		return !(num % 2);
+		return num % 2 === 0;
 	};
 
 	// A simple map that stores items in an array.
@@ -121,6 +121,22 @@ try{
 	};
 }
 
+function createSerializeMap(Type) {
+	var MapType = Type || ArrayMap;
+	return {
+		unwrap: new MapType(),
+		serialize: new MapType() ,
+		isSerializing: {
+			unwrap: new MapType(),
+			serialize: new MapType()
+		},
+		circularReferenceIsSerializing: {
+			unwrap: new MapType(),
+			serialize: new MapType()
+		}
+	};
+}
+
 function makeSerializer(methodName, symbolsToCheck){
 	// A local variable that is shared with all operations that occur withing a single
 	// outer call to serialize()
@@ -146,22 +162,6 @@ function makeSerializer(methodName, symbolsToCheck){
 		}
 		return this.result;
 	};
-
-	function createSerializeMap(Type) {
-		var MapType = Type || ArrayMap;
-		return {
-			unwrap: new MapType(),
-			serialize: new MapType() ,
-			isSerializing: {
-				unwrap: new MapType(),
-				serialize: new MapType()
-			},
-			circularReferenceIsSerializing: {
-				unwrap: new MapType(),
-				serialize: new MapType()
-			}
-		};
-	}
 
 	return function serializer(value, MapType){
 		if (isSerializedHelper(value)) {
@@ -301,11 +301,11 @@ function addPatch(patches, patch) {
 }
 
 function updateDeepList(target, source, isAssign) {
-	var sourceArray = this.toArray(source);
+	var sourceArray = this.toArray(source); // jshint ignore:line
 
 	var patches = [],
 		lastIndex = -1;
-	this.eachIndex(target, function(curVal, index){
+	this.eachIndex(target, function(curVal, index){ // jshint ignore:line
 		lastIndex = index;
 		// If target has more items than the source.
 		if(index >= sourceArray.length) {
@@ -326,7 +326,7 @@ function updateDeepList(target, source, isAssign) {
 			}
 
 		}
-	}, this);
+	}, this); // jshint ignore:line
 	// add items at the end
 	if(sourceArray.length > lastIndex) {
 		addPatch(patches, {index: lastIndex+1, deleteCount: 0, insert: sourceArray.slice(lastIndex+1)});
@@ -836,7 +836,7 @@ shapeReflections = {
 		return target;
 	},
 	assignDeepList: function(target, source) {
-		return updateDeepList.call(this,target, source, true);
+		return updateDeepList.call(this, target, source, true);
 	},
 	/**
 	 * @function can-reflect.assignDeep assignDeep
@@ -900,7 +900,7 @@ shapeReflections = {
 			if(sourceKeyMap.get(key)) {
 				targetSetKeyValue.call(target, key, sourceGetKeyValue.call(source, key) );
 			}
-		})
+		});
 
 		return target;
 	},
@@ -1065,9 +1065,9 @@ shapeReflections = {
 					proto = Object.getPrototypeOf(obj);
 				} else {
 					// IE-remove-start
-					proto = obj.__proto__;
+					proto = obj.__proto__; // jshint ignore:line
 					// IE-remove-end
-				};
+				}
 				if(proto !== undefined) {
 					return key in proto;
 				} else {

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -115,7 +115,7 @@ QUnit.test("isBuiltIn", function() {
 	if (document) {
 		ok(typeReflections.isBuiltIn(document.createElement('div')), "Elements");
 	}
-	var Foo = function() {}
+	var Foo = function() {};
 	var customObj = new Foo();
 	ok(!typeReflections.isBuiltIn(customObj), "Custom Object");
 	if (testHelpers.mapSupported) {

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -132,6 +132,27 @@ function isPrimitive(obj){
 	}
 }
 
+var coreHasOwn = Object.prototype.hasOwnProperty;
+var funcToString = Function.prototype.toString;
+var objectCtorString = funcToString.call(Object);
+
+function isPlainObject(obj) {
+	// Must be an Object.
+	// Because of IE, we also have to check the presence of the constructor property.
+	// Make sure that DOM nodes and window objects don't pass through, as well
+	if (!obj || typeof obj !== 'object' ) {
+		return false;
+	}
+	var proto = Object.getPrototypeOf(obj);
+	if(proto === Object.prototype || proto === null) {
+		return true;
+	}
+	// partially inspired by lodash: https://github.com/lodash/lodash
+	var Constructor = coreHasOwn.call(proto, 'constructor') && proto.constructor;
+	return typeof Constructor === 'function' && Constructor instanceof Constructor &&
+    	funcToString.call(Constructor) === objectCtorString;
+}
+
 /**
  * @function can-reflect.isBuiltIn isBuiltIn
  * @parent can-reflect/type
@@ -391,27 +412,6 @@ if(supportsSymbols) {
 			return false;
 		}
 	};
-}
-
-var coreHasOwn = Object.prototype.hasOwnProperty;
-var funcToString = Function.prototype.toString;
-var objectCtorString = funcToString.call(Object);
-
-function isPlainObject(obj) {
-	// Must be an Object.
-	// Because of IE, we also have to check the presence of the constructor property.
-	// Make sure that DOM nodes and window objects don't pass through, as well
-	if (!obj || typeof obj !== 'object' ) {
-		return false;
-	}
-	var proto = Object.getPrototypeOf(obj);
-	if(proto === Object.prototype || proto === null) {
-		return true;
-	}
-	// partially inspired by lodash: https://github.com/lodash/lodash
-	var Constructor = coreHasOwn.call(proto, 'constructor') && proto.constructor;
-	return typeof Constructor === 'function' && Constructor instanceof Constructor &&
-    	funcToString.call(Constructor) === objectCtorString;
 }
 
 module.exports = {

--- a/types/map.js
+++ b/types/map.js
@@ -6,7 +6,7 @@ function keysPolyfill() {
   var keys = [];
   var currentIndex = 0;
 
-  this.forEach(function(val, key) {
+  this.forEach(function(val, key) { // jshint ignore:line
     keys.push(key);
   });
 
@@ -17,7 +17,7 @@ function keysPolyfill() {
         done: (currentIndex++ === keys.length)
       };
     }
-  }
+  };
 }
 
 if (typeof Map !== "undefined") {

--- a/types/set.js
+++ b/types/set.js
@@ -45,7 +45,7 @@ if (typeof Set !== "undefined") {
 					  done: (currentIndex++ === arr.length)
 				  };
 			  }
-		  }
+		  };
 	  };
   }
 }


### PR DESCRIPTION
I need a hand resolving these issues so I don't blow up the code.

```js
reflections/shape/shape.js: line 150, col 12, 'createSerializeMap' was used before it was defined.
reflections/shape/shape.js: line 304, col 21, If a strict mode function is executed using function invocation, its 'this' value will be undefined.
reflections/shape/shape.js: line 308, col 3, If a strict mode function is executed using function invocation, its 'this' value will be undefined.
reflections/shape/shape.js: line 329, col 6, If a strict mode function is executed using function invocation, its 'this' value will be undefined.

reflections/type/type.js: line 400, col 10, 'isPlainObject' was used before it was defined.

types/map.js: line 9, col 3, If a strict mode function is executed using function invocation, its 'this' value will be undefined.
```