### PR TITLE
Special case dates when sorting keys

### DIFF
--- a/reflections/shape/schema/schema-test.js
+++ b/reflections/shape/schema/schema-test.js
@@ -71,7 +71,10 @@ QUnit.test('cloneKeySort with dates', function (assert) {
         "z": new Date(1999000)
     };
 
-    assert.equal( JSON.stringify( schemaReflections.cloneKeySort(obj) ), JSON.stringify( same ) );
+    var sorted = schemaReflections.cloneKeySort(obj);
+
+    assert.equal( JSON.stringify( sorted ), JSON.stringify( same ) );
+    assert.equal( sorted.a.getTime(), 2001000 );
 });
 
 QUnit.test("getIdentity", function(){

--- a/reflections/shape/schema/schema-test.js
+++ b/reflections/shape/schema/schema-test.js
@@ -60,6 +60,20 @@ QUnit.test('cloneKeySort with strings', function (assert) {
     assert.equal( JSON.stringify( schemaReflections.cloneKeySort(obj) ), JSON.stringify( same ) );
 });
 
+QUnit.test('cloneKeySort with dates', function (assert) {
+    var obj = {
+        "z": new Date(1999000),
+        "a": new Date(2001000)
+    };
+
+    var same = {
+        "a": new Date(2001000),
+        "z": new Date(1999000)
+    };
+
+    assert.equal( JSON.stringify( schemaReflections.cloneKeySort(obj) ), JSON.stringify( same ) );
+});
+
 QUnit.test("getIdentity", function(){
 
     var value = new MyType(5);

--- a/reflections/shape/schema/schema.js
+++ b/reflections/shape/schema/schema.js
@@ -13,7 +13,7 @@ function comparator(a, b) {
 }
 
 function sort(obj) {
-    if(typeReflections.isPrimitive(obj)) {
+    if(typeReflections.isPrimitive(obj) || obj instanceof Date) {
         return obj;
     }
     var out;


### PR DESCRIPTION
If dates aren't treated as primitive-ish, then they become empty objects in cloneKeySort(), which is undesirable.  This PR treats dates specially (and only dates, as they are likely to be used in queries whereas other special types like RegExp and Set are less likely to be).

Closes #163 