### PR TITLE
Add isScopeLike() type reflection

### DIFF
--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -241,9 +241,13 @@ QUnit.test("isScopeLike", function(assert) {
 		set() {},
 		find() {},
 		peek() {},
-		compute() {},
+		computeData() {},
 		getScope() {},
 		add() {},
+		getHelper() {},
+		getTemplateContext() {},
+		addLetContext() {}, 
+		cloneFromRef() {},
 		_context: {},
 		_meta: {}
 	}), "Scope, duck typed");

--- a/reflections/type/type-test.js
+++ b/reflections/type/type-test.js
@@ -225,3 +225,26 @@ QUnit.test("array -like type is MoreListLikeThanMapLike", function(assert) {
 	var arr = new MyArray();
 	assert.ok(typeReflections.isMoreListLikeThanMapLike(arr), "is array like");
 });
+
+
+QUnit.test("isScopeLike", function(assert) {
+	assert.ok(!typeReflections.isScopeLike({}), "Object");
+	assert.ok(!typeReflections.isScopeLike([]), "Array");
+	var symboled = {};
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isScopeLike"), false);
+	assert.ok(!typeReflections.isScopeLike(symboled), "!@@can.isScopeLike");
+	getSetReflections.setKeyValue(symboled, canSymbol.for("can.isScopeLike"), true);
+	assert.ok(typeReflections.isScopeLike(symboled), "@@can.isScopeLike");
+
+	assert.ok(typeReflections.isScopeLike({
+		get() {},
+		set() {},
+		find() {},
+		peek() {},
+		compute() {},
+		getScope() {},
+		add() {},
+		_context: {},
+		_meta: {}
+	}), "Scope, duck typed");
+});

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -424,12 +424,56 @@ if(supportsNativeSymbols) {
 	};
 }
 
+/**
+ * @function can-reflect.isScopeLike isScopeLike
+ * @parent can-reflect/type
+ *
+ * @description Test if a value represents a can.view.Scope or its API equivalent
+ *
+ * @signature `isScopeLike(obj)`
+ *
+ * Return `true` if `obj` is _not_ a primitive, does _not_ have a falsy value for
+ * [can-symbol/symbols/isScopeLike `@@@@can.isScopeLike`], or implements the public 
+ * API of [can-view-scope] along with `_context` and `_meta` objects; `false` otherwise.
+ *
+ * ```js
+ * canReflect.isScopeLike(null); // -> false
+ * canReflect.isScopeLike(1); // -> false
+ * canReflect.isScopeLike("foo"); // -> false
+ * canReflect.isScopeLike({}); // -> false
+ * canReflect.isScopeLike(function() {}); // -> false
+ * canReflect.isScopeLike([]); // -> false
+ * canReflect.isScopeLike({ [canSymbol.for("can.isScopeLike")]: true }); // -> true
+ * canReflect.isScopeLike({ get(){}, set(){}, find(){}, peek(){}, compute(){}, add(){}, getScope(){}, _meta: {}, _context: {} }); // -> true
+ * canReflect.isScopeLike(new can.view.Scope()); // -> true
+ *
+ * ```
+ *
+ * @param  {*}  obj maybe a Map-like
+ * @return {Boolean}
+ */
+var fnKeys = ["get", "set", "find", "peek", "compute", "add", "getScope"];
+function isScopeLike(obj) {
+	if(isPrimitive(obj)) {
+		return false;
+	}
+	var isScopeLike = obj[canSymbol.for("can.isScopeLike")];
+	if(typeof isScopeLike !== "undefined") {
+		return !!isScopeLike;
+	}
+	return fnKeys.every(function(key) { return typeof obj[key] === "function"; }) &&
+		"_context" in obj &&
+		obj._meta && typeof obj._meta === "object";
+}
+
+
 module.exports = {
 	isConstructorLike: isConstructorLike,
 	isFunctionLike: isFunctionLike,
 	isListLike: isListLike,
 	isMapLike: isMapLike,
 	isObservableLike: isObservableLike,
+	isScopeLike: isScopeLike,
 	isPrimitive: isPrimitive,
 	isBuiltIn: isBuiltIn,
 	isValueLike: isValueLike,

--- a/reflections/type/type.js
+++ b/reflections/type/type.js
@@ -444,7 +444,11 @@ if(supportsNativeSymbols) {
  * canReflect.isScopeLike(function() {}); // -> false
  * canReflect.isScopeLike([]); // -> false
  * canReflect.isScopeLike({ [canSymbol.for("can.isScopeLike")]: true }); // -> true
- * canReflect.isScopeLike({ get(){}, set(){}, find(){}, peek(){}, compute(){}, add(){}, getScope(){}, _meta: {}, _context: {} }); // -> true
+ * canReflect.isScopeLike({
+ *   get(){}, set(){}, find(){}, peek(){}, computeData(){}, add(){}, getScope(){},
+ *   getHelper(){}, getTemplateContext(), addLetContext(){}, cloneFromRef(){},
+ *   _meta: {}, _context: {}
+ * }); // -> true
  * canReflect.isScopeLike(new can.view.Scope()); // -> true
  *
  * ```
@@ -452,7 +456,7 @@ if(supportsNativeSymbols) {
  * @param  {*}  obj maybe a Map-like
  * @return {Boolean}
  */
-var fnKeys = ["get", "set", "find", "peek", "compute", "add", "getScope"];
+var fnKeys = ["get", "set", "find", "peek", "computeData", "add", "getScope", "getHelper", "getTemplateContext", "addLetContext", "cloneFromRef"];
 function isScopeLike(obj) {
 	if(isPrimitive(obj)) {
 		return false;


### PR DESCRIPTION
this will help can-component and other view libraries identify Scope objects even if they are from a different CanJS version or not CanJS at all.